### PR TITLE
Fix: 빌드 실패로 요청 엔드포인트 수정

### DIFF
--- a/client/src/pages/Landing/Landing.jsx
+++ b/client/src/pages/Landing/Landing.jsx
@@ -1,10 +1,10 @@
 import axios from 'axios';
-const config = require(__dirname + '/config.js');
 
 export default function Landing() {
   //---------- 서버와 연결 확인용 코드 ----------
+  // BASE_URL은 aws codeBuild에 환경변수로 등록된 서버의 엔드포인트
   axios
-    .get(config.API_HOST)
+    .get(BASE_URL)
     .then(result => {
       console.log('😃 Server-Client Connection Success!', result);
     })


### PR DESCRIPTION
aws 상의 빌드 프로젝트에서 ec2 엔드포인트를 환경변수로 설정 후 
소스 코드에도 해당 환경 변수 키 값으로 요청하도록 변경