### PR TITLE
[Server] Fix: appspec의 실행 계정과 scripts 파일의 계정 모두 ubuntu로 변경

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -7,10 +7,10 @@ files:
 hooks:
   ApplicationStop:
     - location: scripts/stop.sh
-      runas: root
+      runas: ubuntu
   AfterInstall:
     - location: scripts/initialize.sh
-      runas: root
+      runas: ubuntu
   ApplicationStart:
     - location: scripts/start.sh
-      runas: root
+      runas: ubuntu

--- a/client/src/pages/Landing/Landing.jsx
+++ b/client/src/pages/Landing/Landing.jsx
@@ -4,7 +4,7 @@ export default function Landing() {
   //---------- 서버와 연결 확인용 코드 ----------
   // BASE_URL은 aws codeBuild에 환경변수로 등록된 서버의 엔드포인트
   axios
-    .get('http://ec2-3-36-87-95.ap-northeast-2.compute.amazonaws.com/')
+    .get(BASE_URL)
     .then(result => {
       console.log('😃 Server-Client Connection Success!', result);
     })


### PR DESCRIPTION
## 수정 내역
### 문제 원인
- ec2 내에서 pm2를 실행시키는 계정은 scripts 폴더 안에서 **home/ubuntu**로 설정되어있음
- aws codePipeline에서 애플리케이션을 실행하는 appspec.yml은 **root**에서 실행하게 설정되어있음

### 해결 방법
ec2에서 pm2가 실행 중인 내역을 확인했을 때 ubuntu가 아닌 root에서 실행 중이었기 때문에  클라이언트의 'GET /' 요청을 처리하지 못했다고 생각해서 authbind 가 pm2를 실행시키는 계정을 ubuntu로 변경